### PR TITLE
Fix PHP 7 issue: Incompatible variable handling.

### DIFF
--- a/content.module
+++ b/content.module
@@ -364,8 +364,8 @@ function content_view(&$node, $teaser = FALSE, $page = FALSE) {
  */
 function content_view_field($field, $node, $teaser = FALSE, $page = FALSE) {
   $output = '';
-  if (isset($node->$field['field_name'])) {
-    $items = $node->$field['field_name'];
+  if (isset($node->{$field['field_name']})) {
+    $items = $node->{$field['field_name']};
 
     // Use 'full'/'teaser' if not specified otherwise.
     $node->build_mode = isset($node->build_mode) ? $node->build_mode : NODE_BUILD_NORMAL;
@@ -376,7 +376,7 @@ function content_view_field($field, $node, $teaser = FALSE, $page = FALSE) {
     $function = $module .'_field';
     if (function_exists($function)) {
       $function('sanitize', $node, $field, $items, $teaser, $page);
-      $node->$field['field_name'] = $items;
+      $node->{$field['field_name']} = $items;
     }
 
     $view = content_field('view', $node, $field, $items, $teaser, $page);
@@ -712,7 +712,7 @@ function content_field($op, &$node, $field, &$items, $teaser, $page) {
         foreach (array_keys($field['columns']) as $column) {
           $items[0][$column] = NULL;
         }
-        $node->$field['field_name'] = $items;
+        $node->{$field['field_name']} = $items;
       }
 
       // If there was an AHAH add more button in this field, don't save it.
@@ -1061,13 +1061,13 @@ function content_storage($op, $node) {
 
       // Handle multiple fields.
       foreach ($type['fields'] as $field) {
-        if ($field['multiple'] && isset($node->$field['field_name'])) {
+        if ($field['multiple'] && isset($node->{$field['field_name']})) {
           $db_info = content_database_info($field);
           // Delete and insert, rather than update, in case a value was added.
           if ($op == 'update') {
             db_query('DELETE FROM {'. $db_info['table'] .'} WHERE vid = %d', $node->vid);
           }
-          foreach ($node->$field['field_name'] as $delta => $item) {
+          foreach ($node->{$field['field_name']} as $delta => $item) {
             $record = array();
             foreach ($db_info['columns'] as $column => $attributes) {
               $record[$attributes['column']] = $item[$column];
@@ -1244,7 +1244,7 @@ function _content_field_invoke($op, &$node, $teaser = NULL, $page = NULL) {
 
   $return = array();
   foreach ($type['fields'] as $field) {
-    $items = isset($node->$field['field_name']) ? $node->$field['field_name'] : array();
+    $items = isset($node->{$field['field_name']}) ? $node->{$field['field_name']} : array();
 
     // Make sure AHAH 'add more' button isn't sent to the fields for processing.
     unset($items[$field['field_name'] .'_add_more']);
@@ -1261,8 +1261,8 @@ function _content_field_invoke($op, &$node, $teaser = NULL, $page = NULL) {
       }
     }
     // test for values in $items in case modules added items on insert
-    if (isset($node->$field['field_name']) || count($items)) {
-      $node->$field['field_name'] = $items;
+    if (isset($node->{$field['field_name']}) || count($items)) {
+      $node->{$field['field_name']} = $items;
     }
   }
   return $return;
@@ -1284,7 +1284,7 @@ function _content_field_invoke_default($op, &$node, $teaser = NULL, $page = NULL
   }
   else {
     foreach ($type['fields'] as $field) {
-      $items = isset($node->$field['field_name']) ? $node->$field['field_name'] : array();
+      $items = isset($node->{$field['field_name']}) ? $node->{$field['field_name']} : array();
       $result = content_field($op, $node, $field, $items, $teaser, $page);
       if (is_array($result)) {
         $return = array_merge($return, $result);
@@ -1292,8 +1292,8 @@ function _content_field_invoke_default($op, &$node, $teaser = NULL, $page = NULL
       else if (isset($result)) {
         $return[] = $result;
       }
-      if (isset($node->$field['field_name'])) {
-        $node->$field['field_name'] = $items;
+      if (isset($node->{$field['field_name']})) {
+        $node->{$field['field_name']} = $items;
       }
     }
   }

--- a/includes/content.diff.inc
+++ b/includes/content.diff.inc
@@ -25,11 +25,11 @@ function content_diff($old_node, $new_node) {
       $function = function_exists($function) ? $function : 'content_content_diff_values';
       $old_values = array();
       $new_values = array();
-      if (isset($old_node->$field['field_name'])) {
-        $old_values = $function($old_node, $field, $old_node->$field['field_name']);
+      if (isset($old_node->{$field['field_name']})) {
+        $old_values = $function($old_node, $field, $old_node->{$field['field_name']});
       }
-      if (isset($new_node->$field['field_name'])) {
-        $new_values = $function($new_node, $field, $new_node->$field['field_name']);
+      if (isset($new_node->{$field['field_name']})) {
+        $new_values = $function($new_node, $field, $new_node->{$field['field_name']});
       }
       if ($old_values || $new_values) {
         $result[$field['field_name']] = array(

--- a/includes/content.node_form.inc
+++ b/includes/content.node_form.inc
@@ -58,8 +58,8 @@ function content_field_form(&$form, &$form_state, $field, $get_delta = NULL) {
       // If there was an AHAH add more button in this field, don't save it.
       unset($items[$field['field_name'] .'_add_more']);
     }
-    elseif (!empty($node->$field['field_name'])) {
-      $items = $node->$field['field_name'];
+    elseif (!empty($node->{$field['field_name']})) {
+      $items = $node->{$field['field_name']};
     }
     elseif (empty($node->nid)) {
       if (content_callback('widget', 'default value', $field) != CONTENT_CALLBACK_NONE) {

--- a/includes/content.rules.inc
+++ b/includes/content.rules.inc
@@ -34,7 +34,7 @@ function content_rules_action_populate_field($node, $settings, $element, &$state
   $value = _content_rules_get_field_value($settings, $state);
 
   if (!empty($field) && is_array($value)) {
-    $node->$settings['field_name'] = $value;
+    $node->{$settings['field_name']} = $value;
     return array('node' => $node);
   }
 }
@@ -238,7 +238,7 @@ function content_rules_field_has_value($node, $settings) {
     return FALSE;
   }
 
-  return _content_rules_field_has_value($node->$settings['field_name'], $value);
+  return _content_rules_field_has_value($node->{$settings['field_name']}, $value);
 }
 
 /**
@@ -265,7 +265,7 @@ function content_rules_field_changed($node1, $node2, $settings) {
   // Get information about the field.
   $field = content_fields($settings['field_name'], $node1->type);
 
-  return !empty($field) && !_content_rules_field_has_value($node1->$settings['field_name'], $node2->$settings['field_name']);
+  return !empty($field) && !_content_rules_field_has_value($node1->{$settings['field_name']}, $node2->{$settings['field_name']});
 }
 
 function content_rules_field_changed_form($settings, &$form, &$form_state) {


### PR DESCRIPTION
PHP 7 changed the way it handles variables: In earlier versions
of PHP $foo->$bar['baz'] was interpreted as $foo->{$bar['baz']}
it means ($foo->$bar)['baz'] since version 7. This commit fixes
this issue and works with PHP 5 as well as with PHP 7.

See also
https://secure.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect